### PR TITLE
DB refactor for v1.5

### DIFF
--- a/BotDatabase.py
+++ b/BotDatabase.py
@@ -110,7 +110,7 @@ class ScamBotDatabase():
         server = self.Database.scalars(stmt).first()
 
         if (server is None):
-            Logger.Log(LogLevel.Warn, f"Bot had attempted to set new owner on non-existant server ")
+            Logger.Log(LogLevel.Warn, f"Bot #{BotId} attempted to set new owner on non-assigned server: {ServerId}")
             return
         
         server.owner_discord_user_id = NewOwnerId
@@ -123,7 +123,7 @@ class ScamBotDatabase():
         server = self.Database.scalars(stmt).first()
 
         if (server is None):
-            Logger.Log(LogLevel.Warn, f"Attempted to remove an invalid server id: {ServerId}")
+            Logger.Log(LogLevel.Warn, f"Bot #{BotId} attempted to remove an non-assigned server: {ServerId}")
             return
         
         self.Database.delete(server)

--- a/BotDatabase.py
+++ b/BotDatabase.py
@@ -3,7 +3,9 @@ from BotEnums import BanLookup
 from Logger import Logger, LogLevel
 from Config import Config
 import shutil, time, os
-import sqlite3
+from BotDatabaseSchema import Ban, Server
+from sqlalchemy import create_engine, select, URL, asc, desc
+from sqlalchemy.orm import Session
 
 class ScamBotDatabase():
     Database = None
@@ -17,11 +19,19 @@ class ScamBotDatabase():
 
     def Open(self):
         self.Close()
-        self.Database = sqlite3.connect(Config.GetDBFile())
-        
+
+        database_url = URL.create(
+            'sqlite',
+            username='',
+            password='',
+            host='',
+            database=Config.GetDBFile(),
+        )
+        self.Database = Session(create_engine(database_url))
+
     def Close(self):
         if (self.IsConnected()):
-            self.Database.close()
+            self.Database.get_bind().dispose()
             self.Database = None
             
     def IsConnected(self) -> bool:
@@ -80,30 +90,48 @@ class ScamBotDatabase():
                 
     ### Adding/Updating/Removing Server Entries ###
     def AddBotGuilds(self, ListOwnerAndServerTuples, BotID:int):
-        BotAdditionUpdates = []
+        BotAdditionUpdates:list[Server] = []
         for Entry in ListOwnerAndServerTuples:
-            BotAdditionUpdates.append(Entry + (-1, 0, BotID))
+            server = Server(
+                bot_instance_id = BotID,
+                discord_server_id = Entry.id,
+                owner_discord_user_id = Entry.owner_id,
+                activator_discord_user_id = Entry.owner_id
+            )
+            BotAdditionUpdates.append(server)
         
-        self.Database.executemany("INSERT INTO servers VALUES(?, ?, ?, ?, ?)", BotAdditionUpdates)
+        self.Database.bulk_save_objects(BotAdditionUpdates)
         self.Database.commit()
+
         Logger.Log(LogLevel.Notice, f"Bot #{BotID} had {len(BotAdditionUpdates)} new server updates")
         
     def SetNewServerOwner(self, ServerId:int, NewOwnerId:int, BotId:int):
-        ActivationChanges = []
-        ActivationChanges.append({"Id": ServerId, "OwnerId": NewOwnerId, "BotId": BotId})
-        self.Database.executemany("UPDATE servers SET OwnerId=:OwnerId WHERE Id=:Id AND Instance=:BotId", ActivationChanges)
-        self.Database.commit()
+        stmt = select(Server).where((Server.discord_server_id==ServerId) & (Server.bot_instance_id==BotId))
+        server = self.Database.scalars(stmt).first()
+
+        if (server is None):
+            Logger.Log(LogLevel.Warn, f"Bot had attempted to set new owner on non-existant server ")
+            return
         
+        server.owner_discord_user_id = NewOwnerId
+
+        self.Database.add(server)
+        self.Database.commit()
+           
     def RemoveServerEntry(self, ServerId:int, BotId:int):
-        if (self.IsInServer(ServerId)):  
-            self.Database.execute(f"DELETE FROM servers WHERE Id={ServerId} AND Instance={BotId}")
-            self.Database.commit()
-        else:
-            Logger.Log(LogLevel.Warn, f"Attempted to remove server {ServerId} but we are not in that list!")
-    
-    def SetBotActivationForOwner(self, Servers, IsActive:bool, BotId:int, OwnerId:int=-1, ActivatorId:int=-1):
-        ActivationChanges = []
-        ActivationAdditions = []
+        stmt = select(Server).where((Server.discord_server_id==ServerId) & (Server.bot_instance_id==BotId))
+        server = self.Database.scalars(stmt).first()
+
+        if (server is None):
+            Logger.Log(LogLevel.Warn, f"Attempted to remove an invalid server id: {ServerId}")
+            return
+        
+        self.Database.delete(server)
+        self.Database.commit()
+
+    def SetBotActivationForOwner(self, Servers:list[int], IsActive:bool, BotId:int, OwnerId:int=-1, ActivatorId:int=-1):
+        ActivationChanges:list[int] = []
+        ActivationAdditions:list[int] = []
         ActiveVal = int(IsActive)
         
         for ServerId in Servers:
@@ -112,32 +140,54 @@ class ScamBotDatabase():
             if (not self.IsInServer(ServerId)):
                 # prevent garbage data from happening
                 if (OwnerId > 0):
-                    ActivationAdditions.append((ServerId, OwnerId, ActiveVal, ActivatorId, BotId))
+                    ActivationAdditions.append(ServerId)
+
+                    serverToChange = Server(
+                        bot_instance_id = BotId,
+                        discord_server_id = ServerId,
+                        owner_discord_user_id = OwnerId,
+                        activation_state = ActiveVal,
+                        activator_discord_user_id = ActivatorId, 
+                    )
+                    # should only be true on_guild_join, set for data integrity; ideally would be person who invited the bot to the guild
+                    if (ActivatorId == -1):
+                        serverToChange.activator_discord_user_id = OwnerId
+
+                    self.Database.add(serverToChange)
             else:
-                ActivationChanges.append({"Id": ServerId, "ActivatorId": ActivatorId, "Activated": ActiveVal, "BotId": BotId})
-        
+                ActivationChanges.append(ServerId)
+
+                stmt = select(Server).where(Server.discord_server_id==ServerId)
+                serverToChange = self.Database.scalars(stmt).first()
+                
+                serverToChange.activation_state = ActiveVal
+                serverToChange.activator_discord_user_id = ActivatorId
+
+                self.Database.add(serverToChange)
+
         NumActivationAdditions:int = len(ActivationAdditions)
         NumActivationChanges:int = len(ActivationChanges)
+
         if (NumActivationAdditions > 0):
             Logger.Log(LogLevel.Debug, f"We have {NumActivationAdditions} additions")
-            self.Database.executemany("INSERT INTO servers VALUES(?, ?, ?, ?, ?)", ActivationAdditions)
+
         if (NumActivationChanges > 0):
-            self.Database.executemany("UPDATE servers SET Activated=:Activated, ActivatorId=:ActivatorId WHERE Id=:Id AND Instance=:BotId", ActivationChanges)
             Logger.Log(LogLevel.Notice, f"Server activation changed in {NumActivationChanges} servers to {str(IsActive)} by {ActivatorId}")
+
         self.Database.commit()
         
     ### Reconcile Servers ###
     def ReconcileServers(self, Servers, BotId:int):       
         NewAdditions = []
         # Discord Guild IDs that we will later use to remove
-        ServersIn = []
+        ServersIn:list[int] = []
         # Control server id
         ControlServerID:int = Config().ControlServer
         # Loop through all the servers we are in and grab their guild ids
         for DiscordServer in Servers:
             # Check to see if we know about this server already.
             if (not self.IsInServer(DiscordServer.id)):
-                NewAdditions.append((DiscordServer.id, DiscordServer.owner_id))
+                NewAdditions.append(DiscordServer)
             
             # Ignore the control server but add any other servers to this list.
             if (DiscordServer.id != ControlServerID):
@@ -149,12 +199,12 @@ class ScamBotDatabase():
 
         # Check the current list of servers vs what the database has
         # to see if there are any servers we need to remove
-        res = self.Database.execute(f"SELECT Id FROM servers WHERE Instance={BotId} AND NOT Id={ControlServerID}")
-        AllServersWithThisBot = res.fetchall()
+        stmt = select(Server).where((Server.discord_server_id!=ControlServerID) & (Server.bot_instance_id==BotId))
+        AllServersWithThisBot = list(self.Database.scalars(stmt).all())
         Logger.Log(LogLevel.Debug, f"Bot #{BotId} server count: {len(AllServersWithThisBot)} with discord in {len(ServersIn)}")
         # Go through all the servers in the database for this bot
         for InServerId in AllServersWithThisBot:
-            ServerId = InServerId[0]
+            ServerId = int(InServerId.discord_server_id)
             try:
                 # If we are in the server, then we remove the entry from the list of servers
                 # we are in. This is because this list will be used later to remove entries that
@@ -173,103 +223,124 @@ class ScamBotDatabase():
             return
 
         for ServerToRemove in ServersIn:
-            self.Database.execute(f"DELETE FROM servers where Id={ServerToRemove} AND Instance={BotId}")
-            self.Database.commit()
+            self.RemoveServerEntry(ServerToRemove, BotId)
             Logger.Log(LogLevel.Warn, f"Bot #{BotId} has been removed from server {ServerToRemove}")
 
     ### Query Status ###
     def IsInServer(self, ServerId:int) -> bool:
-        res = self.Database.execute(f"SELECT * FROM servers WHERE Id={ServerId}")
-        if (res.fetchone() is None):
+        stmt = select(Server).where(Server.discord_server_id==ServerId)
+        server = self.Database.scalars(stmt).first()
+        if (server is None):
             return False
-        else:
-            return True
+        return True
     
     def IsActivatedInServer(self, ServerId:int) -> bool:
         if (not self.IsInServer(ServerId)):
             return False
-        
-        res = self.Database.execute(f"SELECT Activated FROM servers WHERE Id={ServerId}")
-        FetchResult = res.fetchone()
-        if (FetchResult[0] == 0):
-            return False
-        else:
+
+        stmt = select(Server).where(Server.discord_server_id==ServerId)
+        server = self.Database.scalars(stmt).first()
+
+        if (server.activation_state):
             return True
 
+        return False
+
     def DoesBanExist(self, TargetId:int) -> bool:
-        result = self.Database.execute(f"SELECT * FROM banslist WHERE Id={TargetId}")
-        if (result.fetchone() is None):
+        stmt = select(Ban).where(Ban.discord_user_id==TargetId)
+        result = self.Database.scalars(stmt).first()
+
+        if (result is None):
             return False
-        else:
-            return True
+
+        return True
     
     # Returns the banner's name, the id and the date
-    def GetBanInfo(self, TargetId:int):
-        return self.Database.execute(f"SELECT BannerName, BannerId, Date FROM banslist WHERE Id={TargetId}").fetchone()
+    def GetBanInfo(self, TargetId:int) -> Ban:
+        stmt = select(Ban).where(Ban.discord_user_id==TargetId)
+        return self.Database.scalars(stmt).first()
 
     ### Adding/Removing Bans ###
     def AddBan(self, TargetId:int, BannerName:str, BannerId:int) -> BanLookup:
-        try:
-            if (self.DoesBanExist(TargetId)):
-                return BanLookup.Duplicate
-        except Exception as ex:
-            Logger.Log(LogLevel.Error, f"Got error {str(ex)}")
-            return BanLookup.DBError
-        
-        data = [(TargetId, BannerName, BannerId, datetime.now())]
-        self.Database.executemany("INSERT INTO banslist VALUES(?, ?, ?, ?)", data)
+        if (self.DoesBanExist(TargetId)):
+            return BanLookup.Duplicate
+
+        ban = Ban(
+            discord_user_id = TargetId,
+            assigner_discord_user_id = BannerId,
+            assigner_discord_user_name = BannerName
+        )
+
+        self.Database.add(ban)
         self.Database.commit()
-        
+
         return BanLookup.Good
     
-    def RemoveBan(self, TargetId:int):
-        try:
-            if (not self.DoesBanExist(TargetId)):
-                return BanLookup.NotExist
-        except Exception as ex:
-            Logger.Log(LogLevel.Error, f"Got error {str(ex)}")
-            return BanLookup.DBError
+    def RemoveBan(self, TargetId:int) -> BanLookup:
+        if (not self.DoesBanExist(TargetId)):
+            return BanLookup.NotExist
         
-        self.Database.execute(f"DELETE FROM banslist where Id={TargetId}")
+        stmt = select(Ban).where(Ban.discord_user_id==TargetId)
+        ban = self.Database.scalars(stmt).first()
+
+        self.Database.delete(ban)
         self.Database.commit()
-        
+
         return BanLookup.Good
     
     ### Getting Server Information ###
-    def GetAllServersOfOwner(self, OwnerId:int):
-        ServersOwnedQuery = self.Database.execute(f"SELECT Activated, Id FROM servers WHERE OwnerId={OwnerId}")
-        return ServersOwnedQuery.fetchall()
-    
+    def GetAllServersOfOwner(self, OwnerId:int) -> list[Server]:
+        stmt = select(Server).where(Server.owner_discord_user_id==OwnerId)
+        servers = self.Database.scalars(stmt).all()
+        
+        if (not len(servers)):
+            Logger.Log(LogLevel.Warn, f"Failed to load servers for given discord user id of: {OwnerId}!")
+        
+        return list(servers)
+        
     def GetOwnerOfServer(self, ServerId:int) -> int:
-        ServersOwnedQuery = self.Database.execute(f"SELECT OwnerId FROM servers WHERE Id={ServerId}")
-        return ServersOwnedQuery.fetchone()[0]
+        stmt = select(Server).where(Server.discord_server_id==ServerId)
+        server = self.Database.scalars(stmt).first()
+
+        if (server is None):
+            Logger.Log(LogLevel.Warn, f"Tried to load owner for non existant server: {ServerId}!")
+            return None
+
+        return int(server.owner_discord_user_id)
     
     def GetBotIdForServer(self, ServerId:int) -> int:
-        ServerIdQuery = self.Database.execute(f"SELECT Instance FROM servers WHERE Id={ServerId}")
-        return ServerIdQuery.fetchone()[0]
-    
-    def GetAllBans(self, NumLastActions:int=0):
-        LimitStr:str = ""
-        if (NumLastActions > 0):
-            LimitStr = f" LIMIT {NumLastActions}"
-        BansListQuery = self.Database.execute(f"SELECT Id, BannerName FROM banslist ORDER BY ROWID DESC{LimitStr}")
-        return BansListQuery.fetchall()
-    
-    def GetAllServers(self, ActivatedOnly:bool=False, OfBotInstance:int=-1):
-        SearchFilter:str = ""
-        if (ActivatedOnly):
-            SearchFilter = " WHERE Activated=1"
-            if (OfBotInstance > -1):
-                SearchFilter = f"{SearchFilter} AND Instance={OfBotInstance}"
-        elif (OfBotInstance > -1):
-            SearchFilter = f" WHERE Instance={OfBotInstance}"
+        stmt = select(Server).where(Server.discord_server_id==ServerId)
+        server = self.Database.scalars(stmt).first()
+
+        if (server is None):
+            Logger.Log(LogLevel.Warn, f"Tried to load bot instance for non existant server: {ServerId}!")
+            return None
+
+        return int(server.bot_instance_id)
+
+    def GetAllBans(self, NumLastActions:int=0) -> list[Ban]:
+        stmt = select(Ban).order_by(desc(Ban.created_at))
         
-        AllServersQuery = self.Database.execute(f"SELECT Id, OwnerId, Activated, Instance FROM servers{SearchFilter}")
-        return AllServersQuery.fetchall()
+        if (NumLastActions):
+            stmt = stmt.limit(NumLastActions)
+        
+        return list(self.Database.scalars(stmt).all())
     
-    def GetAllActivatedServers(self, OfInstance:int=-1):
+    def GetAllServers(self, ActivationState:bool=False, OfInstance:int=-1) -> list[Server]:
+        stmt = select(Server)
+
+        if (ActivationState):
+            stmt = stmt.where(Server.activation_state==ActivationState)
+
+        if (OfInstance > -1):
+            stmt = stmt.where(Server.bot_instance_id==OfInstance)
+
+        return list(self.Database.scalars(stmt).all())
+    
+    def GetAllActivatedServers(self, OfInstance:int=-1) -> list[Server]:
         return self.GetAllServers(True, OfInstance)
     
-    def GetAllDeactivatedServers(self):
-        AllServersQuery = self.Database.execute(f"SELECT Id, OwnerId, Activated, Instance FROM servers WHERE Activated=0")
-        return AllServersQuery.fetchall()
+    def GetAllDeactivatedServers(self) -> list[Server]:
+        stmt = select(Server).where(Server.activation_state==False)
+
+        return list(self.Database.scalars(stmt).all())

--- a/BotDatabaseSchema.py
+++ b/BotDatabaseSchema.py
@@ -26,10 +26,10 @@ class Server(Base):
     __tablename__ = "servers"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    bot_instance_id = Column(String(32), nullable=False)
+    bot_instance_id = Column(Integer, nullable=False, server_default="0")
     discord_server_id = Column(String(32), unique=True, nullable=False)
     owner_discord_user_id = Column(String(32), nullable=False)
     activation_state = Column(Integer, server_default="0")
-    activator_discord_user_id = Column(String(32), nullable=False)
+    activator_discord_user_id = Column(String(32), nullable=False, server_default='-1')
     created_at = Column(DateTime(), server_default=func.now())
     updated_at = Column(DateTime(), server_default=func.now(), onupdate=func.now())

--- a/BotDatabaseSchema.py
+++ b/BotDatabaseSchema.py
@@ -1,0 +1,35 @@
+from sqlalchemy import Column, Integer, DateTime, String
+from sqlalchemy.sql import func
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+class Migration(Base):
+    __tablename__ = "migrations"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    database_version = Column(Integer, nullable=False)
+    created_at = Column(DateTime(), server_default=func.now())
+    updated_at = Column(DateTime(), server_default=func.now(), onupdate=func.now())
+
+class Ban(Base):
+    __tablename__ = "bans"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    discord_user_id = Column(String(32), unique=True, nullable=False)
+    assigner_discord_user_id = Column(String(32), nullable=False)
+    assigner_discord_user_name = Column(String(32), nullable=False)
+    created_at = Column(DateTime(), server_default=func.now())
+    updated_at = Column(DateTime(), server_default=func.now(), onupdate=func.now())
+
+class Server(Base):
+    __tablename__ = "servers"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    bot_instance_id = Column(String(32), nullable=False)
+    discord_server_id = Column(String(32), unique=True, nullable=False)
+    owner_discord_user_id = Column(String(32), nullable=False)
+    activation_state = Column(Integer, server_default="0")
+    activator_discord_user_id = Column(String(32), nullable=False)
+    created_at = Column(DateTime(), server_default=func.now())
+    updated_at = Column(DateTime(), server_default=func.now(), onupdate=func.now())

--- a/BotMain.py
+++ b/BotMain.py
@@ -46,8 +46,6 @@ class DiscordBot(discord.Client):
 
     def __del__(self):
         Logger.Log(LogLevel.Notice, f"Closing the discord scam bot instance {self.BotID} {self}")
-        if (self.Database is not None):
-            self.Database.Close()
        
     ### Event Queueing ###
     def AddAsyncTask(self, TaskToComplete):
@@ -250,9 +248,9 @@ class DiscordBot(discord.Client):
                 else:
                     ActionsAppliedThisLoop += 1
 
-            UserId:int = int(Ban[0])
+            UserId:int = int(Ban.discord_user_id)
             UserToBan = discord.Object(UserId)
-            BanResponse = await self.PerformActionOnServer(Server, UserToBan, f"User banned by {Ban[1]}", True)
+            BanResponse = await self.PerformActionOnServer(Server, UserToBan, f"User banned by {Ban.assigner_discord_user_name}", True)
             # See if the ban did go through.
             if (BanResponse[0] == False):
                 BanResponseFlag:BanResult = BanResponse[1]
@@ -299,7 +297,7 @@ class DiscordBot(discord.Client):
                 else:
                     ActionsAppliedThisLoop += 1
                 
-            ServerId:int = ServerData[0]
+            ServerId:int = int(ServerData.discord_server_id)
             DiscordServer = self.get_guild(ServerId)
             if (DiscordServer is not None):
                 BanResultTuple = await self.PerformActionOnServer(DiscordServer, UserToWorkOn, BanReason, IsBan)

--- a/BotMain.py
+++ b/BotMain.py
@@ -359,9 +359,9 @@ Reported Remotely By: {ReportData['ReportingUserName']}[{ReportData['ReportingUs
         # Figure out who banned them
         if (UserBanned):
             # BannerName, BannerId, Date
-            UserData.add_field(name="Banned By", value=f"{BanData[0]}", inline=False)
+            UserData.add_field(name="Banned By", value=f"{BanData.assigner_discord_user_id}", inline=False)
             # Create a date time format (all of the database timestamps are in iso format)
-            DateTime:datetime = datetime.fromisoformat(BanData[2])
+            DateTime:datetime = datetime.fromisoformat(BanData.updated_at)
             UserData.add_field(name="Banned At", value=f"{discord.utils.format_dt(DateTime)}", inline=False)
             UserData.colour = discord.Colour.red()
         elif (not HasUserData):

--- a/BotMain.py
+++ b/BotMain.py
@@ -410,8 +410,8 @@ Reported Remotely By: {ReportData['ReportingUserName']}[{ReportData['ReportingUs
     async def ReprocessInstance(self, LastActions:int):
         BanQueryResult = self.Database.GetAllBans(LastActions)
         for Ban in BanQueryResult:
-            UserId:int = int(Ban[0])
-            AuthorizerName:str = Ban[1]
+            UserId:int = Ban.discord_user_id
+            AuthorizerName:str = Ban.assigner_discord_user_name
             await self.ProcessActionOnUser(UserId, AuthorizerName, True)
     
     def ScheduleReprocessInstance(self, LastActions:int):

--- a/BotMain.py
+++ b/BotMain.py
@@ -8,7 +8,6 @@ from BotDatabase import ScamBotDatabase
 from queue import SimpleQueue
 from BotCommands import GlobalScamCommands
 from CommandHelpers import CommandErrorHandler
-from datetime import datetime
 
 __all__ = ["DiscordBot"]
 
@@ -361,8 +360,7 @@ Reported Remotely By: {ReportData['ReportingUserName']}[{ReportData['ReportingUs
             # BannerName, BannerId, Date
             UserData.add_field(name="Banned By", value=f"{BanData.assigner_discord_user_id}", inline=False)
             # Create a date time format (all of the database timestamps are in iso format)
-            DateTime:datetime = datetime.fromisoformat(BanData.updated_at)
-            UserData.add_field(name="Banned At", value=f"{discord.utils.format_dt(DateTime)}", inline=False)
+            UserData.add_field(name="Banned At", value=f"{discord.utils.format_dt(BanData.updated_at)}", inline=False)
             UserData.colour = discord.Colour.red()
         elif (not HasUserData):
             UserData.colour = discord.Colour.dark_orange()

--- a/BotSetup.py
+++ b/BotSetup.py
@@ -123,7 +123,7 @@ def SetupDatabases():
         username='',
         password='',
         host='',
-        database='dbtest.db',
+        database=Config.GetDBFile(),
     )
 
     engine = create_engine(database_url)
@@ -133,7 +133,7 @@ def SetupDatabases():
     CurrentVersion=0
 
     # if the old table 'banslist' exists, then it is not using the new ORM versioning scheme and we need to migrate
-    # otherwise we are on the new schtema, and can query the the current database version from migration history
+    # otherwise we are on the new schema, and can query the the current database version from migration history
     if (inspect(engine).has_table("banslist") == True):
         query = text('PRAGMA user_version')
         CurrentVersion = session.execute(query).first()[0]

--- a/BotSetup.py
+++ b/BotSetup.py
@@ -1,14 +1,27 @@
-import sqlite3
 from Config import Config
 from Logger import LogLevel, Logger
+from sqlalchemy import create_engine, select, text, URL, desc
+from sqlalchemy.inspection import inspect
+from sqlalchemy.orm import Session
+from datetime import datetime
+from BotDatabaseSchema import Base, Migration, Ban, Server
 
 class DatabaseMigrator:
-    DATABASE_VERSION=2
+    DATABASE_VERSION=3
     VersionMap={}
     DatabaseCon=None
     
     def __init__(self):
-        self.DatabaseCon = sqlite3.connect(Config.GetDBFile())
+        database_url = URL.create(
+            'sqlite',
+            username='',
+            password='',
+            host='',
+            database=Config.GetDBFile(),
+        )
+
+        self.DatabaseCon = create_engine(database_url)
+
         MatchingObjects = [a for a in dir(self) if a.startswith('upgrade_version') and callable(getattr(self, a))]
         for UpgradeFunc in MatchingObjects:
             VersionKeyStr:str = UpgradeFunc.removeprefix("upgrade_version")
@@ -16,47 +29,137 @@ class DatabaseMigrator:
             VersionNumber:int = int(head)
             self.VersionMap[VersionNumber] = getattr(self, UpgradeFunc)
         
-    def __del__(self):
-        self.DatabaseCon.close()
-    
     def PerformUpgradesFromVersion(self, StartingVersion:int) -> bool:
         for i in range(StartingVersion, self.DATABASE_VERSION):
             # Perform upgrade to version
-            Logger.Log(LogLevel.Debug, f"Performing upgrade to version {i}...")
+            Logger.Log(LogLevel.Debug, f"Performing upgrade to version {i+1}...")
             if (not self.VersionMap[i]()):
-                Logger.Log(LogLevel.Error, f"Unable to perform upgrade to version {i}!")
+                Logger.Log(LogLevel.Error, f"Unable to perform upgrade to version {i+1}!")
                 return False
-            Logger.Log(LogLevel.Debug, f"Successfully upgraded to version {i}")
+            Logger.Log(LogLevel.Debug, f"Successfully upgraded to version {i+1}")
             
         return True
     
     def upgrade_version1to2(self) -> bool:
-        cursor = self.DatabaseCon.cursor()
-        cursor.execute("ALTER TABLE servers ADD ActivatorId INTEGER default 0")
-        cursor.execute("ALTER TABLE servers ADD Instance INTEGER default 0")
-        cursor.execute(f"PRAGMA user_version = 2")
-        self.DatabaseCon.commit()
+        session = Session(self.DatabaseCon)
+        session.execute(text("ALTER TABLE servers ADD ActivatorId INTEGER default 0"))
+        session.execute(text("ALTER TABLE servers ADD Instance INTEGER default 0"))
+        session.execute(text(f"PRAGMA user_version = 2"))
+        session.commit()
+        return True
+
+    def upgrade_version2to3(self) -> bool:
+        session = Session(self.DatabaseCon)
+
+        # store banslist and servers in memory
+        query = text('select * from banslist')
+        banlist = session.execute(query)
+
+        newBanList = []
+        for bans in banlist:
+            newBan = Ban(
+                discord_user_id = bans[0],
+                assigner_discord_user_id = bans[2],
+                assigner_discord_user_name = bans[1],
+                # convert old (local python) datetime to utc (in database) datetime
+                created_at = datetime.utcfromtimestamp(datetime.timestamp(datetime.strptime(bans[3], '%Y-%m-%d %H:%M:%S.%f')))
+            )
+            newBanList.append(newBan)
+        banlist.close()
+
+        query = text('select * from servers')
+        serverlist = session.execute(query)
+
+        newServerList = []
+        for oldServer in serverlist:
+            newServer = Server(
+                bot_instance_id = oldServer[4],
+                discord_server_id = oldServer[0],
+                owner_discord_user_id = oldServer[1],
+                activation_state = oldServer[2],
+                activator_discord_user_id = oldServer[3],
+            ) 
+            newServerList.append(newServer)
+        serverlist.close()
+
+        # drop old tables
+        query = text('drop table banslist')
+        session.execute(query)
+        session.commit()
+
+        query = text('drop table servers')
+        session.execute(query)
+        session.commit()
+
+        # create all the new tables
+        Base.metadata.create_all(self.DatabaseCon)
+
+        # insert newly formatted data
+        session.bulk_save_objects(newBanList)
+        session.bulk_save_objects(newServerList)
+        session.commit()
+
+        # remove ban microseconds to match internal (sqlite) datetime(now) format
+        query = text('UPDATE bans set created_at = datetime(created_at)')
+        session.execute(query) 
+        session.commit()
+
+        # store completed migration version
+        dbVersion = Migration(
+            database_version = self.DATABASE_VERSION
+        )
+        session.add(dbVersion)
+        session.execute(text(f"PRAGMA user_version = 3"))
+
+        session.commit()
+
         return True
 
 def SetupDatabases():
     Logger.Log(LogLevel.Notice, "Loading database for scam bot setup")
-    con = sqlite3.connect(Config.GetDBFile())
-    cursor = con.cursor()
-    CurrentVersion:int = cursor.execute("PRAGMA user_version").fetchone()[0]
+    
+    database_url = URL.create(
+        'sqlite',
+        username='',
+        password='',
+        host='',
+        database='dbtest.db',
+    )
+
+    engine = create_engine(database_url)
+
+    session = Session(engine)
+
+    CurrentVersion=0
+
+    # if the old table 'banslist' exists, then it is not using the new ORM versioning scheme and we need to migrate
+    # otherwise we are on the new schtema, and can query the the current database version from migration history
+    if (inspect(engine).has_table("banslist") == True):
+        query = text('PRAGMA user_version')
+        CurrentVersion = session.execute(query).first()[0]
+
+    if (inspect(engine).has_table("migrations") == True):
+        stmt = select(Migration).order_by(desc(Migration.id))
+        CurrentVersion = session.scalars(stmt).first().database_version
+
     if (CurrentVersion != 0):
         # Version updating for the database
         if (CurrentVersion != DatabaseMigrator.DATABASE_VERSION):
-            NewMigrator = DatabaseMigrator()
-            if (not NewMigrator.PerformUpgradesFromVersion(CurrentVersion)):
+            MigrationManager = DatabaseMigrator()
+            if (not MigrationManager.PerformUpgradesFromVersion(CurrentVersion)):
                 exit()
         else:
             Logger.Log(LogLevel.Debug, f"Database version is currently {CurrentVersion}")
-            con.close()
             return
+    else:
+        Base.metadata.create_all(engine)
 
-    cursor.execute(f"PRAGMA user_version = {DatabaseMigrator.DATABASE_VERSION}")
-    cursor.execute("CREATE TABLE if not EXISTS banslist(Id, BannerName, BannerId, Date)")
-    cursor.execute("CREATE TABLE if not EXISTS servers(Id, OwnerId, Activated, ActivatorId, Instance)")
-    con.commit()
-    con.close()
-    Logger.Log(LogLevel.Notice, "Created the bot databases!")
+        appVersion = Migration(
+            database_version = DatabaseMigrator.DATABASE_VERSION
+        )
+
+        session.add(appVersion)
+        session.execute(text(f"PRAGMA user_version = {DatabaseMigrator.DATABASE_VERSION}"))
+        session.commit()
+
+        Logger.Log(LogLevel.Notice, "Created the bot databases!")

--- a/Main.py
+++ b/Main.py
@@ -76,8 +76,8 @@ if __name__ == '__main__':
         ActivatedServers:int = 0
         QueryResults = ScamGuardBot.Database.GetAllServers(False)
         for BotServers in QueryResults:
-            IsActivated:bool = bool(BotServers[2])
-            ReplyStr += f"#{RowNum}: Inst {BotServers[3]}, Server {BotServers[0]}, Owner {BotServers[1]}, Activated {str(IsActivated)}\n"
+            IsActivated:bool = bool(BotServers.activation_state)
+            ReplyStr += f"#{RowNum}: Inst {BotServers.activator_discord_user_id}, Server {BotServers.discord_server_id}, Owner {BotServers.owner_discord_user_id}, Activated {str(IsActivated)}\n"
             RowNum += 1
             if (IsActivated):
                 ActivatedServers += 1

--- a/ScamGuard.py
+++ b/ScamGuard.py
@@ -158,9 +158,9 @@ class ScamGuard(DiscordBot):
         # Figure out who banned them
         if (UserBanned):
             # BannerName, BannerId, Date
-            UserData.add_field(name="Banned By", value=f"{BanData[0]}", inline=False)
+            UserData.add_field(name="Banned By", value=f"{BanData.assigner_discord_user_id}", inline=False)
             # Create a date time format (all of the database timestamps are in iso format)
-            DateTime:datetime = datetime.fromisoformat(BanData[2])
+            DateTime:datetime = datetime.fromisoformat(BanData.updated_at)
             UserData.add_field(name="Banned At", value=f"{discord.utils.format_dt(DateTime)}", inline=False)
             UserData.colour = discord.Colour.red()
         elif (not HasUserData):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 colorama==0.4.6
 discord.py==2.3.2
 python-dotenv==1.0.0
+sqlalchemy
+sqlalchemy.orm


### PR DESCRIPTION
closes https://github.com/SocksTheWolf/AntiScamBot/issues/7

A less opinionated database refactor to attempt a one to one conversion of the current raw SQL queries to an ORM library (SQLAlchemy) in order for the data returned from the database to be agnostic to the database engine selected, and allow for clarity on which fields are referenced, i.e. **object**._named_value_ versus **object**[_random_index_].

Will also allow for easier future migrations of the database should the project needs grow, or the database engine of choice change, e.g. sqlite to mysql/mariadb or postgres.


Opinions chosen are:
- a migrations table has been added to internally track database migrations and the date which they occurred.
- table names are the pluralized form of the object type class name, i.e. each row in the `servers` table is a `Server` object, et cet.
- all fields are now properly typed for safety with sane defaults to allow cleaner object creation in code.
- all fields are now named to more clearly identify the values to be stored in them should an external editor be used for raw access
- all data contains basic historical record of last value updated timestamp for possible audit purposes.
- all fields referencing a discord value have been set to width of 32, as maximum discord id numbers are 18 in length, and maximum textual identifiers (nicknames) are 32 in length.
- fields using datetime stamps are using the database internal function to generate the timestamp for uniformity; thus all timestamps are in UTC ensuring no timezone 'drift' which could cause confusion. This also allows for displaying time in either server location (hardcoded) / client location (possibly dynamic) timezone without need to worry about the source timezone due to said uniformity.
- field names follow generic naming convention with the following 'rules': (object reference) (object qualifier) (qualifier type) (object type). For example:
  - **bot_instance_id** would be an **instance** _(qualifier_type)_ **id** _(object_type)_ for a **bot** _(object_qualifier)_
  - **owner_discord_user_id** would be the **owner** _(object reference)_ of a **discord** _(object_qualifier)_ **user** _(qualifier_type)_ **id** _(object_type)_.
  - The reasons for this is to more easily describe the data inside the column, and more so due to the fact discord snowflakes cannot be decoded, nor is there a function to determine the type of snowflake (user/guild/message id) without actually querying for a result against every single query function via the API to see which one does not error out.


Visualization of the new database schema:
![schema](https://github.com/SocksTheWolf/AntiScamBot/assets/33106048/fdaf29cf-5d3b-4277-a417-432cd2653989)


Examples of the new database objects:
![migrations](https://github.com/SocksTheWolf/AntiScamBot/assets/33106048/bba89bd7-46e2-459b-922b-cbfeeb0f983c)
![bans](https://github.com/SocksTheWolf/AntiScamBot/assets/33106048/6559be7b-602c-43a0-a217-776baceff903)
![servers](https://github.com/SocksTheWolf/AntiScamBot/assets/33106048/c551448e-a696-4d54-a484-bc21494af6d7)


Recommendations / To-dos:
- logic checks are currently spread and varying between the calling function, the internals of called function, and the processing of returned data. ideal situation would be functions which directly interface with the database should be privatized to prevent bad data from being passed, and all logic checks should be moved to a public function to which the data is passed, and then returned to the caller.
- there are currently 3 different ways to add a server to the database, `AddBotGuilds` , `SetBotActivationForOwner` and `ReconcileServers` all which handle it in a different way.
  - Ideally `SetBotActivationForOwner` would only switch activation state
  - With this codebase, `activator_discord_user_id` cannot be null, thus it is set to the owner of the server on first join, and updated by the `interaction.user_id` on state change via `SetBotActivationForOwner`. Ideally, it would initially be set to the person who invited the bot to the server in `on_guild_join`

Current Caveats:
- do not have a discord to validate all functionality, thus testing has been limited to the database functions only; however all code has been confirmed to execute properly and data modification has been validated.