### PR TITLE
Document ScamGuard Commands

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -129,7 +129,7 @@ Commands listed here are grouped by access via execution location.
 |     |     |
 | --- | --- | 
 | Description | Checks to see if a userid is banned |
-| Permissions needed | ban members |
+| Permissions | can ban members |
 
 | Arguments | Type |
 | --- | --- |
@@ -140,13 +140,13 @@ Commands listed here are grouped by access via execution location.
 | --- | --- | 
 | Description | Run ScamGuard setup |
 | Cooldown | once every 5 seconds |
-| Permissions needed | ban members |
+| Permissions | can ban members |
 
 ### `config`
 |     |     |
 | --- | --- | 
 | Description | Configure ScamGuard settings |
-| Permissions needed | ban members |
+| Permissions | can ban members |
 
 ### `info`
 |     |     |

--- a/documentation.md
+++ b/documentation.md
@@ -5,7 +5,7 @@ Certain commands have access restrictions consisting of any, or all of the follo
 Commands listed here are grouped by access via execution location.
 
 ## Administrative
-> These commands can be accessed via `/scamguard drea` and are only available only on the primary command and control server
+> These commands can be accessed via `/scamguard` and are only available only on the primary command and control server
 
 ### `info`
 |     |     |
@@ -122,7 +122,7 @@ Commands listed here are grouped by access via execution location.
 ## Global
 > These commands can be run on any external server where ScamGuard is joined
 
-### `check userid`
+### `/check userid`
 |     |     |
 | --- | --- | 
 | Description | Checks to see if a userid is banned |
@@ -132,7 +132,7 @@ Commands listed here are grouped by access via execution location.
 | --- | --- |
 | userid | discord userid to check |
 
-### `report userid`
+### `/report userid`
 |     |     |
 | --- | --- | 
 | Description | Report a userid |
@@ -143,7 +143,7 @@ Commands listed here are grouped by access via execution location.
 | --- | --- |
 | userid | discord userid to report |
 
-### `reportuser user`
+### `/reportuser user`
 |     |     |
 | --- | --- | 
 | Description | Report a user by @user mention |
@@ -154,20 +154,20 @@ Commands listed here are grouped by access via execution location.
 | --- | --- |
 | user | discord user to check |
 
-### `setup`
+### `/setup`
 |     |     |
 | --- | --- | 
 | Description | Run ScamGuard setup |
 | Cooldown | once every 5 seconds |
 | Permissions | can ban members |
 
-### `config`
+### `/config`
 |     |     |
 | --- | --- | 
 | Description | Configure ScamGuard settings |
 | Permissions | can ban members |
 
-### `info`
+### `/info`
 |     |     |
 | --- | --- | 
 | Description | Prints info and stats about ScamGuard |

--- a/documentation.md
+++ b/documentation.md
@@ -1,13 +1,11 @@
 #  ScamGuard Command Documentation
 
-The commands for the bot can be accessed by running them via `/scamguard command`.
-
 Certain commands have access restrictions consisting of any, or all of the following: cooldown, execution location, role, permission; these are detailed inside each command.
 
 Commands listed here are grouped by access via execution location.
 
 ## Administrative
-> These commands are only available only on the primary command and control server
+> These commands can be accessed via `/scamguard drea` and are only available only on the primary command and control server
 
 ### `info`
 |     |     |
@@ -121,9 +119,8 @@ Commands listed here are grouped by access via execution location.
 | --- | --- |
 | userid | discord userid to check |
 
-
 ## Global
-> These commands can be run on any server where ScamGuard is joined
+> These commands can be run on any external server where ScamGuard is joined
 
 ### `check userid`
 |     |     |
@@ -134,6 +131,28 @@ Commands listed here are grouped by access via execution location.
 | Arguments | Type |
 | --- | --- |
 | userid | discord userid to check |
+
+### `report userid`
+|     |     |
+| --- | --- | 
+| Description | Report a userid |
+| Cooldown | once every 5 seconds |
+| Permissions | can ban members |
+
+| Arguments | Type |
+| --- | --- |
+| userid | discord userid to report |
+
+### `reportuser user`
+|     |     |
+| --- | --- | 
+| Description | Report a user by @user mention |
+| Cooldown | once every 5 seconds |
+| Permissions | can ban members |
+
+| Arguments | Type |
+| --- | --- |
+| user | discord user to check |
 
 ### `setup`
 |     |     |

--- a/documentation.md
+++ b/documentation.md
@@ -120,9 +120,9 @@ Commands listed here are grouped by access via execution location.
 | userid | discord userid to check |
 
 ## Global
-> These commands can be run on any external server where ScamGuard is joined
+> These commands can be accessed via `/scamguard` and are available on any external server where ScamGuard is joined
 
-### `/check userid`
+### `check userid`
 |     |     |
 | --- | --- | 
 | Description | Checks to see if a userid is banned |
@@ -132,7 +132,7 @@ Commands listed here are grouped by access via execution location.
 | --- | --- |
 | userid | discord userid to check |
 
-### `/report userid`
+### `report userid`
 |     |     |
 | --- | --- | 
 | Description | Report a userid |
@@ -143,7 +143,7 @@ Commands listed here are grouped by access via execution location.
 | --- | --- |
 | userid | discord userid to report |
 
-### `/reportuser user`
+### `reportuser user`
 |     |     |
 | --- | --- | 
 | Description | Report a user by @user mention |
@@ -154,20 +154,20 @@ Commands listed here are grouped by access via execution location.
 | --- | --- |
 | user | discord user to check |
 
-### `/setup`
+### `setup`
 |     |     |
 | --- | --- | 
 | Description | Run ScamGuard setup |
 | Cooldown | once every 5 seconds |
 | Permissions | can ban members |
 
-### `/config`
+### `config`
 |     |     |
 | --- | --- | 
 | Description | Configure ScamGuard settings |
 | Permissions | can ban members |
 
-### `/info`
+### `info`
 |     |     |
 | --- | --- | 
 | Description | Prints info and stats about ScamGuard |

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,155 @@
+#  ScamGuard Command Documentation
+
+The commands for the bot can be accessed by running them via `/scamguard command`.
+
+Certain commands have access restrictions consisting of any, or all of the following: cooldown, execution location, role, permission; these are detailed inside each command.
+
+Commands listed here are grouped by access via execution location.
+
+## Administrative
+> These commands are only available only on the primary command and control server
+
+### `info`
+|     |     |
+| --- | --- | 
+| Description | Prints an embed with details about ScamGuard |
+| Cooldown | once every 3 seconds |
+| Restricted to | MaintainerRole |
+
+### `backup`
+|     |     |
+| --- | --- | 
+| Description | Causes ScamGuard to backup and archive its internal database outside of its normal scheduled time |
+| Restricted to | MaintainerRole |
+
+### `forceleave server`
+|     |     |
+| --- | --- | 
+| Description | Forces ScamGuard to leave |
+| Cooldown | once every 3 seconds |
+| Restricted to | MaintainerRole |
+
+| Arguments | Type |
+| --- | --- |
+| server |  discord id of a server |
+
+### `forceactivate server`
+|     |     |
+| --- | --- | 
+| Description | Forces ScamGuard activate on a server |
+| Restricted to | MaintainerRole |
+
+| Arguments | Type |
+| --- | --- |
+| server | discord id of a server |
+
+### `retryactions server count`
+|     |     |
+| --- | --- | 
+| Description | Forces ScamGuard to retry a set of actions on a server |
+| Restricted to | MaintainerRole |
+
+| Arguments | Type |
+| --- | --- |
+| server |  discord id of a server |
+| count | count of last actions to retry |
+
+### `retryinstance instance count`
+|     |     |
+| --- | --- | 
+| Description | Forces ScamGuard to retry a set of actions for a instance of ScamGuard |
+| Restricted to | MaintainerRole |
+
+| Arguments | Type |
+| --- | --- |
+| instance | id of a ScamGuard instance |
+| count | count of last actions to retry |
+
+### `ping instance`
+|     |     |
+| --- | --- | 
+| Description | Pings an instance of ScamGuard |
+| Restricted to | MaintainerRole |
+
+| Arguments | Type |
+| --- | --- |
+| instance | id of a ScamGuard instance |
+
+### `print`
+|     |     |
+| --- | --- | 
+| Description | Prints stats and information about all connected ScamGuard instances |
+| Restricted to | MaintainerRole |
+
+### `scamban userid`
+|     |     |
+| --- | --- | 
+| Description | Bans a user id |
+| Restricted to | MaintainerRole |
+
+| Arguments | Type |
+| --- | --- |
+| userid | discord userid to ban |
+
+### `scamunban userid`
+|     |     |
+| --- | --- | 
+| Description | Unbans a user id |
+| Restricted to | MaintainerRole |
+
+| Arguments | Type |
+| --- | --- |
+| userid | discord userid to unban |
+
+### `activate`
+|     |     |
+| --- | --- | 
+| Description | Activates all servers and brings in previous bans if caller owns any known servers |
+
+### `deactivate`
+|     |     |
+| --- | --- | 
+| Description | Deactivates all servers and prevents any future ban information from being shared if the caller owns any known servers |
+
+### `scamcheck userid`
+|     |     |
+| --- | --- | 
+| Description | Checks to see if a userid is banned |
+| Cooldown | once every 3 seconds |
+
+| Arguments | Type |
+| --- | --- |
+| userid | discord userid to check |
+
+
+## Global
+> These commands can be run on any server where ScamGuard is joined
+
+### `check userid`
+|     |     |
+| --- | --- | 
+| Description | Checks to see if a userid is banned |
+| Permissions needed | ban members |
+
+| Arguments | Type |
+| --- | --- |
+| userid | discord userid to check |
+
+### `setup`
+|     |     |
+| --- | --- | 
+| Description | Run ScamGuard setup |
+| Cooldown | once every 5 seconds |
+| Permissions needed | ban members |
+
+### `config`
+|     |     |
+| --- | --- | 
+| Description | Configure ScamGuard settings |
+| Permissions needed | ban members |
+
+### `info`
+|     |     |
+| --- | --- | 
+| Description | Prints info and stats about ScamGuard |
+| Cooldown | once every 5 seconds |


### PR DESCRIPTION
initial pass at collating and collecting all ScamGuard commands into one file and document purpose and parameters for #46 

Formatting is tentative as markdown is fairly limited as to what it can create for this style of documentation.

Note: documenting these commands highlights several commands which are near identical and could possibly be merged for deduplication and made as aliases.